### PR TITLE
Fixed camera missing reference exception on finishing game in Unity

### DIFF
--- a/Assets/Scripts/Entities/Functions/OffCameraDetector.cs
+++ b/Assets/Scripts/Entities/Functions/OffCameraDetector.cs
@@ -17,9 +17,30 @@ namespace Entities.Functions
 
         private void OnBecameInvisible()
         {
-            if(_camera is null)
+            if (!HasAccessToCamera()) 
                 return;
-            
+
+            SignalOffCamera();
+        }
+
+        private bool HasAccessToCamera()
+        {
+            try
+            {
+                // ReSharper disable once Unity.NoNullPropagation
+                if (_camera?.gameObject is null)
+                    return false;
+            }
+            catch
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private void SignalOffCamera()
+        {
             var position = transform.position;
             var bounds = _camera.GetVisibleBounds();
 


### PR DESCRIPTION
Помилка оказалась трохи масштабнішою, ніж я думав, бо могла вилітати навіть під час самої перевірки на null, якщо:
1) запустити гру;
2) перейти на інший рівень;
3) зупинити гру.

Щоб пофіксити і це - додав ще блок try catch, що зробило уже перевірку настільки великою, що виніс її в окремий метод.

Що скажеш на рахунок цього? Я переборщив і можна зробити простіше чи в цій ситуації нормальне рішення?